### PR TITLE
Migrate crates to Gen2 format

### DIFF
--- a/.github/ISSUE_TEMPLATE/fix-crate.md
+++ b/.github/ISSUE_TEMPLATE/fix-crate.md
@@ -14,7 +14,6 @@ assignees: ''
 
 **Broken on index:**
 - [ ] Stable
-- [ ] Nightly
 
 **Targets Broken on**
 
@@ -29,10 +28,11 @@ Tier 1: Crates must build on these platforms
 Tier 2: Crates optionally build for these platforms, but if one fails the entire build fails
 - [ ] x86_64-pc-windows-msvc
 - [ ] aarch64-pc-windows-msvc
-- [ ] i686-pc-windows-msvc
 - [ ] x86_64-unknown-freebsd
 - [ ] riscv64gc-unknown-linux-gnu
 - [ ] s390x-unknown-linux-gnu
+- [ ] armv7-unknown-linux-gnueabihf
+- [ ] armv7-unknown-linux-musleabihf
 
 Tier 3: Crates optionally build for these platforms, but the build will still publish if any fail
 - [ ] x86_64-unknown-netbsd
@@ -44,17 +44,7 @@ Tier 3: Crates optionally build for these platforms, but the build will still pu
 - [ ] mips64-unknown-linux-muslabi64
 - [ ] mips64el-unknown-linux-gnuabi64
 - [ ] mips64el-unknown-linux-muslabi64
-- [ ] i686-unknown-linux-gnu
-- [ ] i686-unknown-linux-musl
-- [ ] i686-unknown-freebsd
-- [ ] armv7-unknown-linux-gnueabihf
-- [ ] armv7-unknown-linux-musleabihf
-- [ ] powerpc-unknown-linux-gnu
-- [ ] mips-unknown-linux-gnu
-- [ ] mips-unknown-linux-musl
-- [ ] mipsel-unknown-linux-gnu
-- [ ] mipsel-unknown-linux-musl
 
 **Testing Environment**
- - OS(s): [e.g. MacOS 13, Windows 11, Ubuntu Focal]
+ - OS(s): [e.g. MacOS 13, Windows 11, Ubuntu 22.04]
  - Rust Version: [e.g. 1.67.0]

--- a/.github/ISSUE_TEMPLATE/request-crate.md
+++ b/.github/ISSUE_TEMPLATE/request-crate.md
@@ -11,12 +11,11 @@ assignees: ''
 
 **Details**
 - Crates.io URL: 
-- GitHub URL: 
+- Git URL: 
 - License: 
 
 **Requested index to add to:**
 - [ ] Stable
-- [ ] Nightly
 
 **Targets Tested on**
 
@@ -31,10 +30,11 @@ Tier 1: Crates must build on these platforms
 Tier 2: Crates optionally build for these platforms, but if one fails the entire build fails
 - [ ] x86_64-pc-windows-msvc
 - [ ] aarch64-pc-windows-msvc
-- [ ] i686-pc-windows-msvc
 - [ ] x86_64-unknown-freebsd
 - [ ] riscv64gc-unknown-linux-gnu
 - [ ] s390x-unknown-linux-gnu
+- [ ] armv7-unknown-linux-gnueabihf
+- [ ] armv7-unknown-linux-musleabihf
 
 Tier 3: Crates optionally build for these platforms, but the build will still publish if any fail
 - [ ] x86_64-unknown-netbsd
@@ -46,17 +46,7 @@ Tier 3: Crates optionally build for these platforms, but the build will still pu
 - [ ] mips64-unknown-linux-muslabi64
 - [ ] mips64el-unknown-linux-gnuabi64
 - [ ] mips64el-unknown-linux-muslabi64
-- [ ] i686-unknown-linux-gnu
-- [ ] i686-unknown-linux-musl
-- [ ] i686-unknown-freebsd
-- [ ] armv7-unknown-linux-gnueabihf
-- [ ] armv7-unknown-linux-musleabihf
-- [ ] powerpc-unknown-linux-gnu
-- [ ] mips-unknown-linux-gnu
-- [ ] mips-unknown-linux-musl
-- [ ] mipsel-unknown-linux-gnu
-- [ ] mipsel-unknown-linux-musl
 
 **Testing Environment**
- - OS(s): [e.g. MacOS 13, Windows 11, Ubuntu Focal]
+ - OS(s): [e.g. MacOS 13, Windows 11, Ubuntu 22.04]
  - Rust Version: [e.g. 1.67.0]

--- a/crates.json
+++ b/crates.json
@@ -1,23 +1,5 @@
 {
   "crates": {
-    "wiki-tui": {
-      "flags": "--features reqwest/native-tls-vendored",
-      "unsupported": "x86_64-unknown-illumos,x86_64-sun-solaris",
-      "git": "https://github.com/Builditluc/wiki-tui",
-      "bins": [
-        "wiki-tui"
-      ]
-    },
-
-    "exa": {
-      "flags": "",
-      "unsupported": "aarch64-pc-windows-msvc,x86_64-pc-windows-msvc,i686-pc-windows-msvc,x86_64-unknown-illumos,x86_64-sun-solaris",
-      "git": "https://github.com/ogham/exa",
-      "bins": [
-        "exa"
-      ]
-    },
-
     "rtx-cli": {
       "flags": "",
       "unsupported": "aarch64-pc-windows-msvc,x86_64-pc-windows-msvc,i686-pc-windows-msvc,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",

--- a/crates.json
+++ b/crates.json
@@ -9,33 +9,6 @@
       ]
     },
 
-    "zellij": {
-      "flags": "",
-      "unsupported": "aarch64-pc-windows-msvc,x86_64-pc-windows-msvc,i686-pc-windows-msvc,x86_64-unknown-freebsd,x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-linux-musl,i686-unknown-freebsd,armv7-unknown-linux-gnueabihf,armv7-unknown-linux-musleabihf,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
-      "git": "https://github.com/zellij-org/zellij",
-      "bins": [
-        "zellij"
-      ]
-    },
-
-    "hyperfine": {
-      "flags": "",
-      "unsupported": "",
-      "git": "https://github.com/sharkdp/hyperfine",
-      "bins": [
-        "hyperfine"
-      ]
-    },
-
-    "cargo-zigbuild": {
-      "flags": "",
-      "unsupported": "",
-      "git": "https://github.com/rust-cross/cargo-zigbuild",
-      "bins": [
-        "cargo-zigbuild"
-      ]
-    },
-
     "erdtree": {
       "flags": "",
       "unsupported": "x86_64-pc-windows-msvc,aarch64-pc-windows-msvc,i686-pc-windows-msvc,x86_64-unknown-freebsd,x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,i686-unknown-freebsd",

--- a/crates.json
+++ b/crates.json
@@ -1,23 +1,5 @@
 {
   "crates": {
-    "irust": {
-      "flags": "",
-      "unsupported": "x86_64-sun-solaris",
-      "git": "https://github.com/sigmaSd/IRust",
-      "bins": [
-        "irust"
-      ]
-    },
-
-    "evcxr_jupyter": {
-      "flags": "",
-      "unsupported": "x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,armv7-unknown-linux-gnueabihf,armv7-unknown-linux-musleabihf,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
-      "git": "https://github.com/google/evcxr",
-      "bins": [
-        "evcxr_jupyter"
-      ]
-    },
-
     "cargo-info": {
       "flags": "--no-default-features --features rustls",
       "unsupported": "aarch64-pc-windows-msvc,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",

--- a/crates.json
+++ b/crates.json
@@ -1,14 +1,5 @@
 {
   "crates": {
-    "cargo-info": {
-      "flags": "--no-default-features --features rustls",
-      "unsupported": "aarch64-pc-windows-msvc,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
-      "git": "https://gitlab.com/imp/cargo-info",
-      "bins": [
-        "cargo-info"
-      ]
-    },
-
     "wiki-tui": {
       "flags": "--features reqwest/native-tls-vendored",
       "unsupported": "x86_64-unknown-illumos,x86_64-sun-solaris",

--- a/crates.json
+++ b/crates.json
@@ -1,23 +1,5 @@
 {
   "crates": {
-    "zp": {
-      "flags": "",
-      "unsupported": "x86_64-sun-solaris",
-      "git": "https://github.com/bahdotsh/zp",
-      "bins": [
-        "zp"
-      ]
-    },
-
-    "deepl-api": {
-      "flags": "--features reqwest/native-tls-vendored",
-      "unsupported": "x86_64-unknown-illumos,x86_64-sun-solaris",
-      "git": "https://github.com/mgruner/deepl-api-rs",
-      "bins": [
-        "deepl"
-      ]
-    },
-
     "rustic-rs": {
       "flags": "",
       "unsupported": "aarch64-pc-windows-msvc,x86_64-unknown-illumos,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
@@ -33,15 +15,6 @@
       "git": "https://github.com/zifeo/whiz",
       "bins": [
         "whiz"
-      ]
-    },
-
-    "typos-cli": {
-      "flags": "",
-      "unsupported": "",
-      "git": "https://github.com/crate-ci/typos",
-      "bins": [
-        "typos"
       ]
     },
 

--- a/crates.json
+++ b/crates.json
@@ -1,23 +1,5 @@
 {
   "crates": {
-    "nu": {
-      "flags": "--features static-link-openssl",
-      "unsupported": "x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-muslabi64",
-      "git": "https://github.com/nushell/nushell",
-      "bins": [
-        "nu"
-      ]
-    },
-
-    "bob-nvim": {
-      "flags": "",
-      "unsupported": "aarch64-pc-windows-msvc,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
-      "git": "https://github.com/MordechaiHadad/bob",
-      "bins": [
-        "bob"
-      ]
-    },
-
     "gitui": {
       "flags": "",
       "unsupported": "x86_64-unknown-netbsd,x86_64-sun-solaris,i686-unknown-freebsd",

--- a/crates.json
+++ b/crates.json
@@ -1,14 +1,5 @@
 {
   "crates": {
-    "gitui": {
-      "flags": "",
-      "unsupported": "x86_64-unknown-netbsd,x86_64-sun-solaris,i686-unknown-freebsd",
-      "git": "https://github.com/extrawurst/gitui",
-      "bins": [
-        "gitui"
-      ]
-    },
-
     "irust": {
       "flags": "",
       "unsupported": "x86_64-sun-solaris",

--- a/crates.json
+++ b/crates.json
@@ -1,14 +1,5 @@
 {
   "crates": {
-    "rtx-cli": {
-      "flags": "",
-      "unsupported": "aarch64-pc-windows-msvc,x86_64-pc-windows-msvc,i686-pc-windows-msvc,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
-      "git": "https://github.com/jdxcode/rtx",
-      "bins": [
-        "rtx"
-      ]
-    },
-
     "erdtree": {
       "flags": "",
       "unsupported": "x86_64-pc-windows-msvc,aarch64-pc-windows-msvc,i686-pc-windows-msvc,x86_64-unknown-freebsd,x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,i686-unknown-freebsd",
@@ -33,15 +24,6 @@
       "git": "https://github.com/funbiscuit/spacedisplay-rs",
       "bins": [
         "spacedisplay"
-      ]
-    },
-
-    "rust-script": {
-      "flags": "",
-      "unsupported": "",
-      "git": "https://github.com/fornwall/rust-script",
-      "bins": [
-        "rust-script"
       ]
     },
 

--- a/crates.json
+++ b/crates.json
@@ -1,59 +1,5 @@
 {
   "crates": {
-    "rustic-rs": {
-      "flags": "",
-      "unsupported": "aarch64-pc-windows-msvc,x86_64-unknown-illumos,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
-      "git": "https://github.com/rustic-rs/rustic",
-      "bins": [
-        "rustic"
-      ]
-    },
-
-    "whiz": {
-      "flags": "",
-      "unsupported": "x86_64-unknown-illumos,x86_64-sun-solaris",
-      "git": "https://github.com/zifeo/whiz",
-      "bins": [
-        "whiz"
-      ]
-    },
-
-    "xsv": {
-      "flags": "",
-      "unsupported": "x86_64-unknown-illumos",
-      "git": "https://github.com/BurntSushi/xsv",
-      "bins": [
-        "xsv"
-      ]
-    },
-
-    "wthrr": {
-      "flags": "--features reqwest/native-tls-vendored",
-      "unsupported": "x86_64-unknown-illumos,x86_64-sun-solaris",
-      "git": "https://github.com/tobealive/wthrr-the-weathercrab",
-      "bins": [
-        "wthrr"
-      ]
-    },
-
-    "websocat": {
-      "flags": "--features vendored_openssl",
-      "unsupported": "aarch64-pc-windows-msvc",
-      "git": "https://github.com/vi/websocat",
-      "bins": [
-        "websocat"
-      ]
-    },
-
-    "watchexec-cli": {
-      "flags": "",
-      "unsupported": "x86_64-unknown-illumos,x86_64-sun-solaris,mips-unknown-linux-musl,mipsel-unknown-linux-musl",
-      "git": "https://github.com/watchexec/watchexec",
-      "bins": [
-        "watchexec"
-      ]
-    },
-
     "cargo-wasi": {
       "flags": "",
       "unsupported": "aarch64-pc-windows-msvc,x86_64-unknown-illumos,x86_64-sun-solaris,riscv64gc-unknown-linux-gnu,powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,s390x-unknown-linux-gnu,mips64-unknown-linux-gnuabi64,mips64-unknown-linux-muslabi64,mips64el-unknown-linux-gnuabi64,mips64el-unknown-linux-muslabi64,i686-unknown-freebsd,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",

--- a/crates.json
+++ b/crates.json
@@ -1,32 +1,5 @@
 {
   "crates": {
-    "erdtree": {
-      "flags": "",
-      "unsupported": "x86_64-pc-windows-msvc,aarch64-pc-windows-msvc,i686-pc-windows-msvc,x86_64-unknown-freebsd,x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,i686-unknown-freebsd",
-      "git": "https://github.com/solidiquis/erdtree",
-      "bins": [
-        "erd"
-      ]
-    },
-
-    "cargo-semver-checks": {
-      "flags": "",
-      "unsupported": "x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,i686-unknown-freebsd",
-      "git": "https://github.com/obi1kenobi/cargo-semver-checks",
-      "bins": [
-        "cargo-semver-checks"
-      ]
-    },
-
-    "spacedisplay": {
-      "flags": "",
-      "unsupported": "x86_64-unknown-freebsd,x86_64-unknown-netbsd,x86_64-unknown-illumos,x86_64-sun-solaris,i686-unknown-linux-gnu,i686-unknown-linux-musl,i686-unknown-freebsd,armv7-unknown-linux-gnueabihf,armv7-unknown-linux-musleabihf,powerpc-unknown-linux-gnu,mips-unknown-linux-gnu,mips-unknown-linux-musl,mipsel-unknown-linux-gnu,mipsel-unknown-linux-musl",
-      "git": "https://github.com/funbiscuit/spacedisplay-rs",
-      "bins": [
-        "spacedisplay"
-      ]
-    },
-
     "zp": {
       "flags": "",
       "unsupported": "x86_64-sun-solaris",

--- a/crates/cargo-info.toml
+++ b/crates/cargo-info.toml
@@ -1,0 +1,9 @@
+[info]
+id = "cargo-info"
+git = "https://gitlab.com/imp/cargo-info"
+unsupported = []
+bins = ["cargo-info"]
+
+[target.all]
+features = "rustls"
+no-default-features = true

--- a/crates/cargo-info.toml
+++ b/crates/cargo-info.toml
@@ -1,7 +1,18 @@
 [info]
 id = "cargo-info"
 git = "https://gitlab.com/imp/cargo-info"
-unsupported = []
+unsupported = [
+    "riscv64gc-unknown-linux-gnu",
+    "s390x-unknown-linux-gnu",
+    "aarch64-pc-windows-msvc",
+    "x86_64-sun-solaris",
+    "powerpc64-unknown-linux-gnu",
+    "powerpc64le-unknown-linux-gnu",
+    "mips64-unknown-linux-gnuabi64",
+    "mips64-unknown-linux-muslabi64",
+    "mips64el-unknown-linux-gnuabi64",
+    "mips64el-unknown-linux-muslabi64"
+]
 bins = ["cargo-info"]
 
 [target.all]

--- a/crates/cargo-semver-checks.toml
+++ b/crates/cargo-semver-checks.toml
@@ -1,0 +1,5 @@
+[info]
+id = "cargo-semver-checks"
+git = "https://github.com/obi1kenobi/cargo-semver-checks"
+unsupported = []
+bins = ["cargo-semver-checks"]

--- a/crates/cargo-semver-checks.toml
+++ b/crates/cargo-semver-checks.toml
@@ -1,5 +1,9 @@
 [info]
 id = "cargo-semver-checks"
 git = "https://github.com/obi1kenobi/cargo-semver-checks"
-unsupported = []
+unsupported = [
+    "x86_64-unknown-netbsd",
+    "x86_64-unknown-illumos",
+    "x86_64-sun-solaris"
+]
 bins = ["cargo-semver-checks"]

--- a/crates/cargo-zigbuild.toml
+++ b/crates/cargo-zigbuild.toml
@@ -1,0 +1,5 @@
+[info]
+id = "cargo-zigbuild"
+git = "https://github.com/rust-cross/cargo-zigbuild"
+unsupported = []
+bins = ["cargo-zigbuild"]

--- a/crates/deepl-api.toml
+++ b/crates/deepl-api.toml
@@ -1,0 +1,8 @@
+[info]
+id = "deepl-api"
+git = "https://github.com/mgruner/deepl-api-rs"
+unsupported = []
+bins = ["deepl"]
+
+[target.all]
+features = "reqwest/native-tls-vendored"

--- a/crates/deepl-api.toml
+++ b/crates/deepl-api.toml
@@ -1,7 +1,7 @@
 [info]
 id = "deepl-api"
 git = "https://github.com/mgruner/deepl-api-rs"
-unsupported = []
+unsupported = ["x86_64-unknown-illumos", "x86_64-sun-solaris"]
 bins = ["deepl"]
 
 [target.all]

--- a/crates/erdtree.toml
+++ b/crates/erdtree.toml
@@ -1,5 +1,11 @@
 [info]
 id = "erdtree"
 git = "https://github.com/solidiquis/erdtree"
-unsupported = []
+unsupported = [
+    "x86_64-unknown-freebsd",
+    "x86_64-pc-windows-msvc",
+    "aarch64-pc-windows-msvc",
+    "x86_64-unknown-illumos",
+    "x86_64-sun-solaris"
+]
 bins = ["erd"]

--- a/crates/erdtree.toml
+++ b/crates/erdtree.toml
@@ -1,0 +1,5 @@
+[info]
+id = "erdtree"
+git = "https://github.com/solidiquis/erdtree"
+unsupported = []
+bins = ["erd"]

--- a/crates/evcxr_jupyter.toml
+++ b/crates/evcxr_jupyter.toml
@@ -1,0 +1,5 @@
+[info]
+id = "evcxr_jupyter"
+git = "https://github.com/google/evcxr"
+unsupported = []
+bins = ["evcxr_jupyter"]

--- a/crates/evcxr_jupyter.toml
+++ b/crates/evcxr_jupyter.toml
@@ -1,5 +1,13 @@
 [info]
 id = "evcxr_jupyter"
 git = "https://github.com/google/evcxr"
-unsupported = []
+unsupported = [
+    "x86_64-unknown-netbsd",
+    "x86_64-unknown-illumos",
+    "x86_64-sun-solaris",
+    "mips64-unknown-linux-gnuabi64",
+    "mips64-unknown-linux-muslabi64",
+    "mips64el-unknown-linux-gnuabi64",
+    "mips64el-unknown-linux-muslabi64"
+]
 bins = ["evcxr_jupyter"]

--- a/crates/exa.toml
+++ b/crates/exa.toml
@@ -1,7 +1,14 @@
 [info]
 id = "exa"
 git = "https://github.com/ogham/exa"
-unsupported = []
+unsupported = [
+    "x86_64-pc-windows-msvc",
+    "aarch64-pc-windows-msvc",
+    "x86_64-unknown-illumos",
+    "x86_64-sun-solaris",
+    "mips64-unknown-linux-muslabi64",
+    "mips64el-unknown-linux-muslabi64"
+]
 bins = ["exa"]
 
 [target.all]

--- a/crates/exa.toml
+++ b/crates/exa.toml
@@ -1,0 +1,8 @@
+[info]
+id = "exa"
+git = "https://github.com/ogham/exa"
+unsupported = []
+bins = ["exa"]
+
+[target.all]
+features = "vendored-openssl"

--- a/crates/gitui.toml
+++ b/crates/gitui.toml
@@ -1,0 +1,5 @@
+[info]
+id = "gitui"
+git = "https://github.com/extrawurst/gitui"
+unsupported = []
+bins = ["gitui"]

--- a/crates/gitui.toml
+++ b/crates/gitui.toml
@@ -1,5 +1,5 @@
 [info]
 id = "gitui"
 git = "https://github.com/extrawurst/gitui"
-unsupported = []
+unsupported = ["x86_64-unknown-netbsd", "x86_64-sun-solaris"]
 bins = ["gitui"]

--- a/crates/hyperfine.toml
+++ b/crates/hyperfine.toml
@@ -1,0 +1,5 @@
+[info]
+id = "hyperfine"
+git = "https://github.com/sharkdp/hyperfine"
+unsupported = []
+bins = ["hyperfine"]

--- a/crates/irust.toml
+++ b/crates/irust.toml
@@ -1,0 +1,5 @@
+[info]
+id = "irust"
+git = "https://github.com/sigmaSd/IRust"
+unsupported = []
+bins = ["irust"]

--- a/crates/irust.toml
+++ b/crates/irust.toml
@@ -1,5 +1,5 @@
 [info]
 id = "irust"
 git = "https://github.com/sigmaSd/IRust"
-unsupported = []
+unsupported = ["x86_64-sun-solaris"]
 bins = ["irust"]

--- a/crates/rtx-cli.toml
+++ b/crates/rtx-cli.toml
@@ -1,0 +1,8 @@
+[info]
+id = "rtx-cli"
+git = "https://github.com/jdxcode/rtx"
+unsupported = []
+bins = ["rtx"]
+
+[target.all]
+features = "alpine,brew,deb,rpm"

--- a/crates/rtx-cli.toml
+++ b/crates/rtx-cli.toml
@@ -4,6 +4,7 @@ git = "https://github.com/jdxcode/rtx"
 unsupported = [
     "riscv64gc-unknown-linux-gnu",
     "s390x-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
     "aarch64-pc-windows-msvc",
     "x86_64-sun-solaris",
     "powerpc64-unknown-linux-gnu",

--- a/crates/rtx-cli.toml
+++ b/crates/rtx-cli.toml
@@ -1,7 +1,18 @@
 [info]
 id = "rtx-cli"
 git = "https://github.com/jdxcode/rtx"
-unsupported = []
+unsupported = [
+    "riscv64gc-unknown-linux-gnu",
+    "s390x-unknown-linux-gnu",
+    "aarch64-pc-windows-msvc",
+    "x86_64-sun-solaris",
+    "powerpc64-unknown-linux-gnu",
+    "powerpc64le-unknown-linux-gnu",
+    "mips64-unknown-linux-gnuabi64",
+    "mips64-unknown-linux-muslabi64",
+    "mips64el-unknown-linux-gnuabi64",
+    "mips64el-unknown-linux-muslabi64"
+]
 bins = ["rtx"]
 
 [target.all]

--- a/crates/rust-script.toml
+++ b/crates/rust-script.toml
@@ -1,0 +1,5 @@
+[info]
+id = "rust-script"
+git = "https://github.com/fornwall/rust-script"
+unsupported = []
+bins = ["rust-script"]

--- a/crates/rustic-rs.toml
+++ b/crates/rustic-rs.toml
@@ -1,5 +1,17 @@
 [info]
 id = "rustic-rs"
 git = "https://github.com/rustic-rs/rustic"
-unsupported = []
+unsupported = [
+    "riscv64gc-unknown-linux-gnu",
+    "s390x-unknown-linux-gnu",
+    "aarch64-pc-windows-msvc",
+    "x86_64-unknown-illumos",
+    "x86_64-sun-solaris",
+    "powerpc64-unknown-linux-gnu",
+    "powerpc64le-unknown-linux-gnu",
+    "mips64-unknown-linux-gnuabi64",
+    "mips64-unknown-linux-muslabi64",
+    "mips64el-unknown-linux-gnuabi64",
+    "mips64el-unknown-linux-muslabi64"
+]
 bins = ["rustic"]

--- a/crates/rustic-rs.toml
+++ b/crates/rustic-rs.toml
@@ -1,0 +1,5 @@
+[info]
+id = "rustic-rs"
+git = "https://github.com/rustic-rs/rustic"
+unsupported = []
+bins = ["rustic"]

--- a/crates/spacedisplay.toml
+++ b/crates/spacedisplay.toml
@@ -1,0 +1,5 @@
+[info]
+id = "spacedisplay"
+git = "https://github.com/funbiscuit/spacedisplay-rs"
+unsupported = []
+bins = ["spacedisplay"]

--- a/crates/spacedisplay.toml
+++ b/crates/spacedisplay.toml
@@ -1,5 +1,12 @@
 [info]
 id = "spacedisplay"
 git = "https://github.com/funbiscuit/spacedisplay-rs"
-unsupported = []
+unsupported = [
+    "x86_64-unknown-freebsd",
+    "armv7-unknown-linux-gnueabihf",
+    "armv7-unknown-linux-musleabihf",
+    "x86_64-unknown-netbsd",
+    "x86_64-unknown-illumos",
+    "x86_64-sun-solaris",
+]
 bins = ["spacedisplay"]

--- a/crates/typos-cli.toml
+++ b/crates/typos-cli.toml
@@ -1,0 +1,5 @@
+[info]
+id = "typos-cli"
+git = "https://github.com/crate-ci/typos"
+unsupported = []
+bins = ["typos"]

--- a/crates/watchexec-cli.toml
+++ b/crates/watchexec-cli.toml
@@ -1,0 +1,5 @@
+[info]
+id = "watchexec-cli"
+git = "https://github.com/watchexec/watchexec"
+unsupported = []
+bins = ["watchexec"]

--- a/crates/watchexec-cli.toml
+++ b/crates/watchexec-cli.toml
@@ -1,5 +1,9 @@
 [info]
 id = "watchexec-cli"
 git = "https://github.com/watchexec/watchexec"
-unsupported = []
+unsupported = [
+    "s390x-unknown-linux-gnu",
+    "x86_64-unknown-illumos",
+    "x86_64-sun-solaris"
+]
 bins = ["watchexec"]

--- a/crates/websocat.toml
+++ b/crates/websocat.toml
@@ -1,0 +1,8 @@
+[info]
+id = "websocat"
+git = "https://github.com/vi/websocat"
+unsupported = []
+bins = ["websocat"]
+
+[target.all]
+features = "vendored_openssl"

--- a/crates/websocat.toml
+++ b/crates/websocat.toml
@@ -1,7 +1,7 @@
 [info]
 id = "websocat"
 git = "https://github.com/vi/websocat"
-unsupported = []
+unsupported = ["aarch64-pc-windows-msvc"]
 bins = ["websocat"]
 
 [target.all]

--- a/crates/whiz.toml
+++ b/crates/whiz.toml
@@ -1,5 +1,5 @@
 [info]
 id = "whiz"
 git = "https://github.com/zifeo/whiz"
-unsupported = []
+unsupported = ["x86_64-unknown-illumos", "x86_64-sun-solaris"]
 bins = ["whiz"]

--- a/crates/whiz.toml
+++ b/crates/whiz.toml
@@ -1,0 +1,5 @@
+[info]
+id = "whiz"
+git = "https://github.com/zifeo/whiz"
+unsupported = []
+bins = ["whiz"]

--- a/crates/wiki-tui.toml
+++ b/crates/wiki-tui.toml
@@ -1,7 +1,7 @@
 [info]
 id = "wiki-tui"
 git = "https://github.com/Builditluc/wiki-tui"
-unsupported = []
+unsupported = ["x86_64-unknown-illumos", "x86_64-sun-solaris"]
 bins = ["wiki-tui"]
 
 [target.all]

--- a/crates/wiki-tui.toml
+++ b/crates/wiki-tui.toml
@@ -1,0 +1,8 @@
+[info]
+id = "wiki-tui"
+git = "https://github.com/Builditluc/wiki-tui"
+unsupported = []
+bins = ["wiki-tui"]
+
+[target.all]
+features = "reqwest/native-tls-vendored"

--- a/crates/wthrr.toml
+++ b/crates/wthrr.toml
@@ -1,7 +1,7 @@
 [info]
 id = "wthrr"
 git = "https://github.com/tobealive/wthrr-the-weathercrab"
-unsupported = []
+unsupported = ["x86_64-unknown-illumos", "x86_64-sun-solaris"]
 bins = ["wthrr"]
 
 [target.all]

--- a/crates/wthrr.toml
+++ b/crates/wthrr.toml
@@ -1,0 +1,8 @@
+[info]
+id = "wthrr"
+git = "https://github.com/tobealive/wthrr-the-weathercrab"
+unsupported = []
+bins = ["wthrr"]
+
+[target.all]
+features = "reqwest/native-tls-vendored"

--- a/crates/xsv.toml
+++ b/crates/xsv.toml
@@ -1,0 +1,5 @@
+[info]
+id = "xsv"
+git = "https://github.com/BurntSushi/xsv"
+unsupported = []
+bins = ["xsv"]

--- a/crates/xsv.toml
+++ b/crates/xsv.toml
@@ -1,5 +1,5 @@
 [info]
 id = "xsv"
 git = "https://github.com/BurntSushi/xsv"
-unsupported = []
+unsupported = ["x86_64-unknown-illumos"]
 bins = ["xsv"]

--- a/crates/zellij.toml
+++ b/crates/zellij.toml
@@ -1,0 +1,5 @@
+[info]
+id = "zellij"
+git = "https://github.com/zellij-org/zellij"
+unsupported = []
+bins = ["zellij"]

--- a/crates/zellij.toml
+++ b/crates/zellij.toml
@@ -1,5 +1,21 @@
 [info]
 id = "zellij"
 git = "https://github.com/zellij-org/zellij"
-unsupported = []
+unsupported = [
+    "x86_64-unknown-freebsd",
+    "s390x-unknown-linux-gnu",
+    "armv7-unknown-linux-gnueabihf",
+    "armv7-unknown-linux-musleabihf",
+    "x86_64-pc-windows-msvc",
+    "aarch64-pc-windows-msvc",
+    "x86_64-unknown-netbsd",
+    "x86_64-unknown-illumos",
+    "x86_64-sun-solaris",
+    "powerpc64-unknown-linux-gnu",
+    "powerpc64le-unknown-linux-gnu",
+    "mips64-unknown-linux-gnuabi64",
+    "mips64-unknown-linux-muslabi64",
+    "mips64el-unknown-linux-gnuabi64",
+    "mips64el-unknown-linux-muslabi64"
+]
 bins = ["zellij"]

--- a/crates/zp.toml
+++ b/crates/zp.toml
@@ -1,0 +1,5 @@
+[info]
+id = "zp"
+git = "https://github.com/bahdotsh/zp"
+unsupported = []
+bins = ["zp"]

--- a/crates/zp.toml
+++ b/crates/zp.toml
@@ -1,5 +1,5 @@
 [info]
 id = "zp"
 git = "https://github.com/bahdotsh/zp"
-unsupported = []
+unsupported = ["x86_64-sun-solaris"]
 bins = ["zp"]

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-zp,deepl-api,typos-cli
+zp,deepl-api

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-rustic-rs,whiz,xsv,wthrr,websocat
+wthrr,websocat,watchexec-cli

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-gitui
+gitui,irust,evcxr_jupyter

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-rtx-cli,zellij,hyperfine,cargo-zigbuild
+rtx-cli,erdtree,cargo-semver-checks,spacedisplay,rust-script

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-rtx-cli,erdtree,cargo-semver-checks,spacedisplay,rust-script
+erdtree,cargo-semver-checks,spacedisplay

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-wiki-tui,exa,rtx-cli,zellij
+rtx-cli,zellij,hyperfine,cargo-zigbuild

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-wthrr,websocat,watchexec-cli
+watchexec-cli

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-irust,evcxr_jupyter,cargo-info
+cargo-info,wiki-tui,exa

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-gitui,irust,evcxr_jupyter
+irust,evcxr_jupyter,cargo-info

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-rustic-rs,whiz,xsv
+rustic-rs,whiz,xsv,wthrr,websocat

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-cargo-prebuilt
+gitui

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-erdtree,cargo-semver-checks,spacedisplay
+zp,deepl-api,typos-cli

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-zp,deepl-api
+rustic-rs,whiz,xsv

--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-cargo-info,wiki-tui,exa
+wiki-tui,exa,rtx-cli,zellij


### PR DESCRIPTION
- [x] gitui
- [x] irust
- [x] evcxr_jupyter
- [x] cargo-info
- [x] wiki-tui
- [x] exa
- [x] rtx-cli
- [x] zellij
- [x] hyperfine
- [x] cargo-zigbuild
- [x] erdtree
- [x] cargo-semver-checks
- [x] spacedisplay
- [x] rust-script
- [x] zp
- [x] deepl-api
- [x] typos-cli
- [x] rustic-rs
- [x] whiz
- [x] xsv
- [x] wthrr
- [x] websocat
- [x] watchexec-cli