### PR TITLE
MacOS 14 runners

### DIFF
--- a/pr/_allowlist
+++ b/pr/_allowlist
@@ -1,1 +1,1 @@
-cargo-prebuilt,bindgen-cli
+whiz

--- a/stable.template.yml
+++ b/stable.template.yml
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [ x86_64-apple-darwin, aarch64-apple-darwin ]
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: [ setup ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- [x] Closes #211 

MacOS-14 seems to be much faster then MacOS-Latest. Time to test crates in index to see if there are any problems.

Errors:
- cargo-workspaces: Ignore general error